### PR TITLE
Adds docker-compose file and disables graphical Dialog on apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04.4
 
 # Enable 32Bit programs
-RUN dpkg --add-architecture i386 && apt-get update && apt-get install libc6:i386 -y
+RUN dpkg --add-architecture i386 && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install libc6:i386 -yq
 
 COPY app /app/
 COPY entrypoint.sh /app/

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ The original installer asked to agree to this: [License](license.txt), so only c
 
 ## Connect
 Start your Palace client and connect to [palace://localhost:9998](palace://localhost:9998)
+
+## Using docker-compose
+`docker-compose up --build`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+   
+services:
+  palaceserver:
+    build: .
+    ports:
+      - "9998:9998"
+      - "9990:9990"


### PR DESCRIPTION
⭐️ Adds docker-compose.yml file
⭐️ Turns `apt-get install` non-interactive in `Dockerfile`